### PR TITLE
Add server-user option for modern rstudio-server images

### DIFF
--- a/local/start_rstudio_server.sh
+++ b/local/start_rstudio_server.sh
@@ -6,7 +6,7 @@
 ##############################################
 
 CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-USER=`whoami`
+USER=$(whoami)
 # set a user-specific secure cookie key
 COOKIE_KEY_PATH=/tmp/rstudio-server/${USER}_secure-cookie-key
 rm -f $COOKIE_KEY_PATH
@@ -40,6 +40,7 @@ export RETICULATE_PYTHON=$CONDA_PREFIX/bin/python
   --rsession-which-r=$(which R) \
   --rsession-ld-library-path=$CONDA_PREFIX/lib \
   --rsession-path="$CWD/rsession.sh" \
+  --server-user $USER \
   $REVOCATION_LIST_PAR
 
 

--- a/singularity/Singularity
+++ b/singularity/Singularity
@@ -7,7 +7,7 @@ From: rocker/rstudio
 
 %post
     echo "lock-type=linkbased" > /etc/rstudio/file-locks
-    chmod +x /init.sh
+    chmod 755 /init.sh
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
     bash ~/miniconda.sh -b -p /opt/conda
 

--- a/singularity/init.sh
+++ b/singularity/init.sh
@@ -10,5 +10,6 @@ source /opt/conda/etc/profile.d/conda.sh && \
     `# optional: old behaviour of R sessions` \
     --auth-timeout-minutes=0 --auth-stay-signed-in-days=30  \
     `# activate password authentication` \
-    --auth-none=0  --auth-pam-helper-path=pam-helper
+    --auth-none=0  --auth-pam-helper-path=pam-helper \
+    --server-user $USER
 

--- a/singularity/run_singularity.sh
+++ b/singularity/run_singularity.sh
@@ -4,6 +4,7 @@
 
 # Main parameters for the script with default values
 PORT=${PORT:-8787}
+USER=$(whoami)
 PASSWORD=${PASSWORD:-notsafe}
 TMPDIR=${TMPDIR:-tmp}
 CONTAINER="rstudio_latest.sif"  # path to singularity container (will be automatically downloaded)
@@ -41,6 +42,7 @@ singularity exec \
 	--env RETICULATE_PYTHON=$PY_BIN \
 	--env PASSWORD=$PASSWORD \
 	--env PORT=$PORT \
+	--env USER=$USER \
 	rstudio_latest.sif \
 	/init.sh
 


### PR DESCRIPTION
New rstudio images have option --server-user with default "rstudio-server"
This PR force rstudio to run with current user inside singularity or local run.